### PR TITLE
25 feat/timestamp dirs

### DIFF
--- a/src/cherami/audit_db.py
+++ b/src/cherami/audit_db.py
@@ -15,9 +15,10 @@ class AuditDB:
         self._init_db()
 
     def _connect(self) -> sqlite3.Connection:
-        ## concurrent writes are technically possible - so set some params to wait 30s to acquire a lock
-        ## this should be enough time for most operations
-        ## will raise an OperationalError if it can't acquire the lock in that time which is caught in the worker
+        ## concurrent writes are technically possible - so set some params to
+        ## wait 30s to acquire a lock this should be enough time for most
+        ## operations will raise an OperationalError if it can't acquire the
+        ## lock in that time which is caught in the worker
         conn = sqlite3.connect(self.db_path, timeout=30)
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=30000")
@@ -51,7 +52,8 @@ class AuditDB:
                 """
                 INSERT INTO audit_log (
                     climb_id, job_uuid, pipeline_name, audit_timestamp, status,
-                    error_message, attempt, max_attempts, start_time, end_time, duration
+                    error_message, attempt, max_attempts, start_time, end_time,
+                    duration
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (

--- a/src/cherami/audit_db.py
+++ b/src/cherami/audit_db.py
@@ -32,13 +32,13 @@ class AuditDB:
                     climb_id TEXT NOT NULL,
                     job_uuid TEXT NOT NULL,
                     pipeline_name TEXT NOT NULL,
-                    timestamp TEXT NOT NULL,
+                    audit_timestamp TEXT NOT NULL,
                     status TEXT NOT NULL,
                     error_message TEXT,
                     attempt INTEGER,
                     max_attempts INTEGER,
-                    start_time REAL,
-                    end_time REAL,
+                    start_time TEXT,
+                    end_time TEXT,
                     duration REAL
                 )
                 """
@@ -50,7 +50,7 @@ class AuditDB:
             conn.execute(
                 """
                 INSERT INTO audit_log (
-                    climb_id, job_uuid, pipeline_name, timestamp, status,
+                    climb_id, job_uuid, pipeline_name, audit_timestamp, status,
                     error_message, attempt, max_attempts, start_time, end_time, duration
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,

--- a/src/cherami/pipeline_runner.py
+++ b/src/cherami/pipeline_runner.py
@@ -39,10 +39,11 @@ class PipelineRunner:
     def _cleanup(self, *, job_name: str, pipeline: Pipeline) -> None:
         """Delete a Kubernetes Job and wait for deletion to complete.
 
-        Kubernetes job deletion is asynchronous, so this method polls for up to 180 seconds
-        until the job returns a 404 status, indicating it has been removed. This wait
-        is necessary because attempting to create a new job with the same name before deletion
-        completes will result in a 409 error.
+        Kubernetes job deletion is asynchronous, so this method polls for up to
+        180 seconds until the job returns a 404 status, indicating it has been
+        removed. This wait is necessary because attempting to create a new job
+        with the same name before deletion completes will result in a 409
+        error.
 
         Args:
             job_name: Name of the Kubernetes Job to delete.
@@ -63,8 +64,9 @@ class PipelineRunner:
             if e.status != 404:
                 raise
 
-        ## k8 can sometimes take a while to delete jobs, so waits up to 180s for it to delete
-        ## otherwise a new job with the same uuid cant be created (will get error 409)
+        ## k8 can sometimes take a while to delete jobs, so waits up to 180s
+        ## for it to delete otherwise a new job with the same uuid cant be
+        ## created (will get error 409)
         deadline = time.time() + 180
         while True:
             try:
@@ -94,7 +96,8 @@ class PipelineRunner:
 
         Args:
             pipeline: Pipeline instance being evaluated.
-            job_dirs: Dictionary containing run directories, specifically "output_dir".
+            job_dirs: Dictionary containing run directories, specifically
+            "output_dir".
 
         Returns:
             True if the trace file exists and indicates success.
@@ -162,7 +165,8 @@ class PipelineRunner:
 
                 if failed_count >= pipeline.config.backoff_limit:
                     raise RetryablePipelineError(
-                        f"pod_failure_backoff_limit_exceeded: backoff_limit={pipeline.config.backoff_limit}"
+                        f"pod_failure_backoff_limit_exceeded: "
+                        f"backoff_limit={pipeline.config.backoff_limit}"
                     )
 
             if (
@@ -171,7 +175,8 @@ class PipelineRunner:
                 > pipeline.config.job_timeout
             ):
                 raise RetryablePipelineError(
-                    f"pod_failure_timeout: timeout_seconds={pipeline.config.job_timeout}"
+                    f"pod_failure_timeout: timeout_seconds="
+                    f"{pipeline.config.job_timeout}"
                 )
 
             logger.debug("k8 job still running...")
@@ -188,8 +193,8 @@ class PipelineRunner:
     ) -> None:
         """Create and submit a Kubernetes Job for the pipeline.
 
-        Will "attach" to an existing job if one with the same name is found. Otherwise,
-        creates a new job.
+        Will "attach" to an existing job if one with the same name is found.
+        Otherwise, creates a new job.
 
         Args:
             pipeline: Pipeline instance to run.
@@ -199,13 +204,14 @@ class PipelineRunner:
             job_dirs: Dictionary containing all required run directories.
 
         Raises:
-            ApiException: If Kubernetes API calls fail for reasons other than 409
-                Conflict (which is treated as an existing run).
+            ApiException: If Kubernetes API calls fail for reasons other than
+            409 Conflict (which is treated as an existing run).
         """
-        ## to handle situations where a worker crashes with jobs pending, here poll for an existing job with same
-        ## name, if this returns something we can assume the job is already running or has completed within the k8
-        ## TTL window so can "re-attach" to it and move straight to the validation loop. If the job isnt found, it
-        ## is created like normal
+        ## to handle situations where a worker crashes with jobs pending, here
+        # poll for an existing job with same name, if this returns something we
+        ## can assume the job is already running or has completed within the k8
+        ## TTL window so can "re-attach" to it and move straight to the
+        ## validation loop. If the job isnt found, it is created like normal
         jobs = self.k8_api.list_namespaced_job(
             namespace=pipeline.config.namespace,
             field_selector=f"metadata.name={job_name}",
@@ -231,8 +237,9 @@ class PipelineRunner:
                     namespace=pipeline.config.namespace,
                 )
             except ApiException as e:
-                ## if somehow the first check missed an existing job capture the 409 error here and let it continue
-                ## to the validation loop, otherwise raise any other exceptions
+                ## if somehow the first check missed an existing job capture
+                ## the 409 error here and let it continue to the validation
+                ## loop, otherwise raise any other exceptions
                 if e.status == 409:
                     logger.warning(
                         "Job %s already exists; attaching to existing run",
@@ -261,7 +268,8 @@ class PipelineRunner:
             sample_id: Sample identifier.
             worker_work_dir: Base directory for intermediate work files.
             worker_output_dir: Base directory for final outputs.
-            execution_timestamp: start time of execution - used to make output dirs.
+            execution_timestamp: start time of execution - used to make output
+            dirs.
 
         Returns:
             A dictionary containing paths for:
@@ -327,10 +335,10 @@ class PipelineRunner:
             execution_timestamp: start time on execution.
 
         Raises:
-            RetryablePipelineError: For failures eligible for retry (e.g., API errors,
-                pod crashes, timeouts).
-            NonRetryablePipelineError: For failures not eligible for retry (e.g.,
-                trace validation failure).
+            RetryablePipelineError: For failures eligible for retry (e.g., API
+                errors,pod crashes, timeouts).
+            NonRetryablePipelineError: For failures not eligible for retry
+                (e.g., trace validation failure).
         """
         job_name = f"{pipeline.config.name}-{job_uuid}"
         sample_output_dir = worker_output_dir / sample_id
@@ -410,14 +418,17 @@ class PipelineRunner:
     ) -> None:
         """Launch the given pipeline for a specific sample.
 
-        Runs the given pipeline for a specific sample. This validates the pipeline
+        Runs the given pipeline for a specific sample. This validates the
+        pipeline
         configuration and executes the run.
 
         Args:
             pipeline: Pipeline instance to run.
             sample_id: Unique identifier for the sample.
-            job_uuid: Unique UUID for this pipeline run (from match_uuid in payload).
-            worker_work_dir: Directory for intermediate files and Nextflow work.
+            job_uuid: Unique UUID for this pipeline run (from match_uuid in
+                payload).
+            worker_work_dir: Directory for intermediate files and Nextflow
+                work.
             worker_output_dir: Directory for final published outputs.
             execution_timestamp: start time of execution.
 

--- a/src/cherami/pipeline_runner.py
+++ b/src/cherami/pipeline_runner.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import time
 from pathlib import Path
@@ -161,8 +162,7 @@ class PipelineRunner:
 
                 if failed_count >= pipeline.config.backoff_limit:
                     raise RetryablePipelineError(
-                        "pod_failure_backoff_limit_exceeded: "
-                        f"backoff_limit={pipeline.config.backoff_limit}"
+                        f"pod_failure_backoff_limit_exceeded: backoff_limit={pipeline.config.backoff_limit}"
                     )
 
             if (
@@ -171,8 +171,7 @@ class PipelineRunner:
                 > pipeline.config.job_timeout
             ):
                 raise RetryablePipelineError(
-                    "pod_failure_timeout: "
-                    f"timeout_seconds={pipeline.config.job_timeout}"
+                    f"pod_failure_timeout: timeout_seconds={pipeline.config.job_timeout}"
                 )
 
             logger.debug("k8 job still running...")
@@ -248,7 +247,11 @@ class PipelineRunner:
             )
 
     def _create_dirs(
-        self, sample_id: str, worker_work_dir: Path, worker_output_dir: Path
+        self,
+        sample_id: str,
+        worker_work_dir: Path,
+        worker_output_dir: Path,
+        execution_timestamp: datetime.datetime,
     ) -> dict[str, Path]:
         """Create the directory structure required for a pipeline run.
 
@@ -258,6 +261,7 @@ class PipelineRunner:
             sample_id: Sample identifier.
             worker_work_dir: Base directory for intermediate work files.
             worker_output_dir: Base directory for final outputs.
+            execution_timestamp: start time of execution - used to make output dirs.
 
         Returns:
             A dictionary containing paths for:
@@ -272,8 +276,11 @@ class PipelineRunner:
             OSError: If required directories cannot be created.
         """
         ## creates all the dirs to run a sample
-        sample_work_dir = worker_work_dir / sample_id
-        sample_output_dir = worker_output_dir / sample_id
+        execution_timestamp_str = execution_timestamp.isoformat("T")
+        sample_work_dir = worker_work_dir / sample_id / execution_timestamp_str
+        sample_output_dir = (
+            worker_output_dir / sample_id / execution_timestamp_str
+        )
 
         nxf_work_dir = sample_work_dir / f"{sample_id}_nxf_work"
         nxf_home_dir = worker_work_dir / ".nextflow"
@@ -304,6 +311,7 @@ class PipelineRunner:
         job_uuid: str,
         worker_work_dir: Path,
         worker_output_dir: Path,
+        execution_timestamp: datetime.datetime,
     ) -> None:
         """Submit the Kubernetes Job and return the result of execution.
 
@@ -316,6 +324,7 @@ class PipelineRunner:
             job_uuid: Unique job UUID.
             worker_work_dir: Output directory for intermediate files.
             worker_output_dir: Output directory for published outputs.
+            execution_timestamp: start time on execution.
 
         Raises:
             RetryablePipelineError: For failures eligible for retry (e.g., API errors,
@@ -329,7 +338,7 @@ class PipelineRunner:
         if completion_marker.exists():
             raise NonRetryablePipelineError("pipeline_already_completed")
         job_dirs = self._create_dirs(
-            sample_id, worker_work_dir, worker_output_dir
+            sample_id, worker_work_dir, worker_output_dir, execution_timestamp
         )
 
         try:
@@ -397,6 +406,7 @@ class PipelineRunner:
         job_uuid: str,
         worker_work_dir: Path,
         worker_output_dir: Path,
+        execution_timestamp: datetime.datetime,
     ) -> None:
         """Launch the given pipeline for a specific sample.
 
@@ -409,6 +419,7 @@ class PipelineRunner:
             job_uuid: Unique UUID for this pipeline run (from match_uuid in payload).
             worker_work_dir: Directory for intermediate files and Nextflow work.
             worker_output_dir: Directory for final published outputs.
+            execution_timestamp: start time of execution.
 
         Raises:
             RetryablePipelineError: When a failure is eligible for retry.
@@ -421,4 +432,5 @@ class PipelineRunner:
             job_uuid=job_uuid,
             worker_work_dir=worker_work_dir,
             worker_output_dir=worker_output_dir,
+            execution_timestamp=execution_timestamp,
         )

--- a/src/cherami/pipeline_runner.py
+++ b/src/cherami/pipeline_runner.py
@@ -3,6 +3,7 @@ import logging
 import time
 from pathlib import Path
 
+from kubernetes.client import V1Job
 from kubernetes.client.api import BatchV1Api
 from kubernetes.client.exceptions import ApiException
 from onyx.exceptions import OnyxConnectionError
@@ -182,6 +183,68 @@ class PipelineRunner:
             logger.debug("k8 job still running...")
             time.sleep(10)
 
+    def _build_job_annotations(
+        self,
+        job_dirs: dict[str, Path],
+        execution_timestamp: datetime.datetime,
+    ) -> dict[str, str]:
+        return {
+            "execution_timestamp": execution_timestamp.isoformat("T"),
+            "working_dir": str(job_dirs["working_dir"]),
+            "output_dir": str(job_dirs["output_dir"]),
+            "nxf_work_dir": str(job_dirs["nxf_work_dir"]),
+            "nxf_home_dir": str(job_dirs["nxf_home_dir"]),
+            "nxf_log_file": str(job_dirs["nxf_log_file"]),
+            "samplesheet_path": str(job_dirs["samplesheet_path"]),
+        }
+
+    def _read_job_dirs_from_annotations(
+        self,
+        annotations: dict[str, str] | None,
+    ) -> dict[str, Path]:
+        if not annotations:
+            raise NonRetryablePipelineError(
+                "existing_job_missing_run_metadata"
+            )
+
+        required_keys = [
+            "working_dir",
+            "output_dir",
+            "nxf_work_dir",
+            "nxf_home_dir",
+            "nxf_log_file",
+            "samplesheet_path",
+        ]
+        missing_keys = [key for key in required_keys if key not in annotations]
+        if missing_keys:
+            raise NonRetryablePipelineError(
+                "existing_job_missing_run_metadata"
+            )
+
+        return {
+            "working_dir": Path(annotations["working_dir"]),
+            "output_dir": Path(annotations["output_dir"]),
+            "nxf_work_dir": Path(annotations["nxf_work_dir"]),
+            "nxf_home_dir": Path(annotations["nxf_home_dir"]),
+            "nxf_log_file": Path(annotations["nxf_log_file"]),
+            "samplesheet_path": Path(annotations["samplesheet_path"]),
+        }
+
+    def _get_existing_job(
+        self,
+        *,
+        pipeline: Pipeline,
+        job_name: str,
+    ) -> V1Job | None:
+        jobs = self.k8_api.list_namespaced_job(
+            namespace=pipeline.config.namespace,
+            field_selector=f"metadata.name={job_name}",
+            limit=1,
+        )
+        if not jobs.items:
+            return None
+        return jobs.items[0]
+
     def _create_job(
         self,
         *,
@@ -189,68 +252,67 @@ class PipelineRunner:
         job_name: str,
         sample_id: str,
         job_uuid: str,
-        job_dirs: dict[str, Path],
-    ) -> None:
+        worker_work_dir: Path,
+        worker_output_dir: Path,
+        execution_timestamp: datetime.datetime,
+    ) -> V1Job:
         """Create and submit a Kubernetes Job for the pipeline.
-
-        Will "attach" to an existing job if one with the same name is found.
-        Otherwise, creates a new job.
 
         Args:
             pipeline: Pipeline instance to run.
             job_name: Name for the Kubernetes Job.
             sample_id: Sample identifier.
             job_uuid: Unique job UUID.
-            job_dirs: Dictionary containing all required run directories.
+            worker_work_dir: Base directory for intermediate work files.
+            worker_output_dir: Base directory for final outputs.
+            execution_timestamp: Start time of this execution attempt.
+
+        Returns:
+            The created Kubernetes Job object.
 
         Raises:
             ApiException: If Kubernetes API calls fail for reasons other than
             409 Conflict (which is treated as an existing run).
         """
-        ## to handle situations where a worker crashes with jobs pending, here
-        # poll for an existing job with same name, if this returns something we
-        ## can assume the job is already running or has completed within the k8
-        ## TTL window so can "re-attach" to it and move straight to the
-        ## validation loop. If the job isnt found, it is created like normal
-        jobs = self.k8_api.list_namespaced_job(
-            namespace=pipeline.config.namespace,
-            field_selector=f"metadata.name={job_name}",
-            limit=1,
+        job_dirs = self._create_dirs(
+            sample_id,
+            worker_work_dir,
+            worker_output_dir,
+            execution_timestamp,
         )
-        job_exists = bool(jobs.items)
+        pipeline.generate_samplesheet(
+            [sample_id],
+            job_uuid,
+            job_dirs["samplesheet_path"],
+        )
 
-        if not job_exists:
-            pipeline.generate_samplesheet(
-                [sample_id],
-                job_uuid,
-                job_dirs["samplesheet_path"],
+        job_manifest = pipeline.create_job_manifest(
+            job_id=job_uuid,
+            job_dirs=job_dirs,
+            annotations=self._build_job_annotations(
+                job_dirs,
+                execution_timestamp,
+            ),
+        )
+
+        try:
+            return self.k8_api.create_namespaced_job(
+                body=job_manifest,
+                namespace=pipeline.config.namespace,
             )
+        except ApiException as e:
+            ## if somehow the first check missed an existing job capture the 409 error here and let it continue
+            ## to the validation loop, otherwise raise any other exceptions
+            if e.status != 409:
+                raise
 
-            job_manifest = pipeline.create_job_manifest(
-                job_id=job_uuid,
-                job_dirs=job_dirs,
-            )
-
-            try:
-                self.k8_api.create_namespaced_job(
-                    body=job_manifest,
-                    namespace=pipeline.config.namespace,
-                )
-            except ApiException as e:
-                ## if somehow the first check missed an existing job capture
-                ## the 409 error here and let it continue to the validation
-                ## loop, otherwise raise any other exceptions
-                if e.status == 409:
-                    logger.warning(
-                        "Job %s already exists; attaching to existing run",
-                        job_name,
-                    )
-                else:
-                    raise
-        else:
-            logger.info(
-                "Attaching to existing job %s",
+            logger.warning(
+                "Job %s already exists; attaching to existing run",
                 job_name,
+            )
+            return self.k8_api.read_namespaced_job(
+                name=job_name,
+                namespace=pipeline.config.namespace,
             )
 
     def _create_dirs(
@@ -345,17 +407,27 @@ class PipelineRunner:
         completion_marker = sample_output_dir / ".cherami_complete"
         if completion_marker.exists():
             raise NonRetryablePipelineError("pipeline_already_completed")
-        job_dirs = self._create_dirs(
-            sample_id, worker_work_dir, worker_output_dir, execution_timestamp
-        )
 
         try:
-            self._create_job(
+            job = self._get_existing_job(
                 pipeline=pipeline,
                 job_name=job_name,
-                sample_id=sample_id,
-                job_uuid=job_uuid,
-                job_dirs=job_dirs,
+            )
+            if job is None:
+                job = self._create_job(
+                    pipeline=pipeline,
+                    job_name=job_name,
+                    sample_id=sample_id,
+                    job_uuid=job_uuid,
+                    worker_work_dir=worker_work_dir,
+                    worker_output_dir=worker_output_dir,
+                    execution_timestamp=execution_timestamp,
+                )
+            else:
+                logger.info("Attaching to existing job %s", job_name)
+
+            job_dirs = self._read_job_dirs_from_annotations(
+                job.metadata.annotations
             )
 
             complete = self._poll_job(

--- a/src/cherami/pipelines/pipeline.py
+++ b/src/cherami/pipelines/pipeline.py
@@ -154,9 +154,9 @@ class Pipeline(ABC):
             )
 
         pod_env_values = [
-            ("NXF_WORK", job_dirs["nxf_work_dir"]),
-            ("NXF_HOME", job_dirs["nxf_home_dir"]),
-            ("NXF_LOG_FILE", job_dirs["nxf_log_file"]),
+            ("NXF_WORK", str(job_dirs["nxf_work_dir"])),
+            ("NXF_HOME", str(job_dirs["nxf_home_dir"])),
+            ("NXF_LOG_FILE", str(job_dirs["nxf_log_file"])),
         ]
         pod_env_values.extend(
             (name, os.environ[name]) for name in required_env_vars
@@ -170,6 +170,7 @@ class Pipeline(ABC):
         self,
         job_id: str,
         job_dirs: dict[str, Path],
+        annotations: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Returns the Kubernetes Job manifest for a pipeline run.
 
@@ -177,6 +178,7 @@ class Pipeline(ABC):
             job_id: UUID associated with the sample.
             climb_id: Climb id for a sample.
             job_dirs: Dictionary of filesystem paths used by the job.
+            annotations: Optional Kubernetes Job annotations for this run.
 
         Returns:
             Kubernetes Job manifest dictionary to submit via `create_namespaced_job`.
@@ -209,13 +211,17 @@ class Pipeline(ABC):
         command = " ".join(nextflow_cmd)
         logger.debug("Nextflow command: %s", command)
 
+        metadata = {
+            "name": job_name,
+            "namespace": self.config.namespace,
+        }
+        if annotations:
+            metadata["annotations"] = annotations
+
         return {
             "apiVersion": "batch/v1",
             "kind": "Job",
-            "metadata": {
-                "name": job_name,
-                "namespace": self.config.namespace,
-            },
+            "metadata": metadata,
             "spec": {
                 "ttlSecondsAfterFinished": 120,
                 "backoffLimit": self.config.backoff_limit,

--- a/src/cherami/pipelines/strep_pneumo.py
+++ b/src/cherami/pipelines/strep_pneumo.py
@@ -54,7 +54,9 @@ class StrepPneumoPipeline(Pipeline):
                 try:
                     # Pneumokity requires 2 fastqs as input so for SE pass same fastq twice
                     if climb_records["human_filtered_reads_2"] == "":
-                        climb_records["human_filtered_reads_2"] = climb_records["human_filtered_reads_1"]
+                        climb_records["human_filtered_reads_2"] = (
+                            climb_records["human_filtered_reads_1"]
+                        )
                     row = {
                         "climb_id": climb_id,
                         "fastq_1": climb_records["human_filtered_reads_1"],

--- a/src/cherami/pipelines/worker.py
+++ b/src/cherami/pipelines/worker.py
@@ -55,7 +55,8 @@ class Worker:
         output_dir: Output directory for pipeline results.
         _audit_db: Audit database object logging pipeline events.
         listen_exchange: Varys exchange name for incoming jobs.
-        listen_queue_suffix: Queue suffix for incoming jobs used by varys for queue names.
+        listen_queue_suffix: Queue suffix for incoming jobs used by varys for
+            queue names.
         varys_config_path: Path to the Varys configuration file.
         varys_log_path: Path to the Varys log file.
         publish_queue_suffix: Optional queue suffix for completion messages.
@@ -94,13 +95,14 @@ class Worker:
     def on_skip(self, message: Any) -> None:
         """Handle messages that should be skipped.
 
-        The default implementation acknowledges the message to remove it from the
-        queue.
+        The default implementation acknowledges the message to remove it from
+        the queue.
 
         Override this method to implement custom logic for skipped samples.
 
         Args:
-            message: The Varys message object associated with the current sample.
+            message: The Varys message object associated with the current
+            sample.
 
         Raises:
             Exception: If the Varys client fails to acknowledge the message.
@@ -111,22 +113,26 @@ class Worker:
         """Handle successful pipeline completions.
 
         Publishes the result to a downstream queue if `publish_queue_suffix` is
-        configured, then acknowledges the original message. If `publish_exchange`
-        is not set, it defaults to publishing to the worker's `listen_exchange`.
+        configured, then acknowledges the original message. If
+        `publish_exchange` is not set, it defaults to publishing to the
+        worker's `listen_exchange`.
         This enables chaining workers where one worker's output queue becomes
         the next worker's input.
 
         Override this method to implement custom post-processing logic.
 
         Args:
-            message: The Varys message object associated with the current sample.
+            message: The Varys message object associated with the current
+                sample.
             payload: The message payload to publish downstream.
 
         Raises:
-            Exception: If the Varys client fails to publish or acknowledge the message.
+            Exception: If the Varys client fails to publish or acknowledge the
+                message.
         """
-        ## if a worker configured a publish queue, this  send that message to the listen_exchange,
-        ## unless the worker ALSO configures a publish_exchange, in which case use that
+        ## if a worker configured a publish queue, this  send that message to
+        ## the listen_exchange, unless the worker ALSO configures a
+        ## publish_exchange, in which case use that
         if self.publish_queue_suffix:
             target_exchange = self.publish_exchange or self.listen_exchange
             self._varys_client.send(
@@ -144,14 +150,15 @@ class Worker:
         """Handle pipeline failures eligible for retry.
 
         The default implementation negatively acknowledges (nacks) the message,
-        returning it to the queue for redelivery. The worker tracks retry counts
-        internally and calls to `on_sample_failure` if `max_retries` is
+        returning it to the queue for redelivery. The worker tracks retry
+        counts internally and calls to `on_sample_failure` if `max_retries` is
         exceeded.
 
         Override this method to implement custom retry strategies.
 
         Args:
-            message: The Varys message object associated with the current sample.
+            message: The Varys message object associated with the current
+                sample.
 
         Raises:
             Exception: If the Varys client fails to requeue the message.
@@ -165,14 +172,16 @@ class Worker:
         """Handle permanent pipeline failures.
 
         Invoked when a sample fails and is not eligible for retry (or has
-        exhausted all retry attempts). This method has no default implementation.
+        exhausted all retry attempts). This method has no default
+        implementation.
 
         Override this method to handle terminal failures, such as sending the
         message to a dead-letter queue, logging a detailed error report, or
         alerting an administrator.
 
         Args:
-            message: The Varys message object associated with the current sample.
+            message: The Varys message object associated with the current
+                sample.
         """
         ## TODO: consider publishing to an error queue if configured
 
@@ -182,10 +191,12 @@ class Worker:
     ) -> tuple[dict[str, Any], str, str]:
         """Extract sample information from the message.
 
-        Returns the message payload, sample ID (climb_id), and job UUID (match_uuid).
+        Returns the message payload, sample ID (climb_id), and job UUID
+        (match_uuid).
 
         Args:
-            message: The Varys message object associated with the current sample.
+            message: The Varys message object associated with the current
+            sample.
 
         Returns:
             A tuple containing:
@@ -194,7 +205,8 @@ class Worker:
             - The job UUID (match_uuid).
 
         Raises:
-            ValueError: If the message body is invalid JSON or missing required fields.
+            ValueError: If the message body is invalid JSON or missing required
+            fields.
         """
 
         try:
@@ -223,13 +235,14 @@ class Worker:
     ) -> PipelineResult:
         """Create a structured result object for audit logging.
 
-        Returns a PipelineResult suitable for audit logging. Duration is populated
-        only when both start and end timestamps are provided.
+        Returns a PipelineResult suitable for audit logging. Duration is
+        populated only when both start and end timestamps are provided.
 
         Args:
             climb_id: Sample identifier.
             job_uuid: Unique job UUID.
-            status: Outcome of the pipeline execution (SUCCESS, FAILED, SKIPPED, RETRY).
+            status: Outcome of the pipeline execution
+                (SUCCESS, FAILED, SKIPPED, RETRY).
             error_message: Description of the error if failed or retried.
             attempt: Current attempt number.
             max_attempts: Total allowed retry attempts.
@@ -268,7 +281,8 @@ class Worker:
         Runs the worker until it exits.
 
         Raises:
-            RuntimeError: If the worker exits due to a pipeline error or client initialisation failure.
+            RuntimeError: If the worker exits due to a pipeline error or client
+                initialisation failure.
             ValueError: If an incoming message cannot be parsed.
             Exception: If an unexpected error occurs and the worker exits.
         """
@@ -331,7 +345,8 @@ class Worker:
                     current_config_hash = hash_from_file(self._config_path)
                     if current_config_hash != self._startup_config_hash:
                         logger.warning(
-                            "Config file has changed since startup. Please restart the worker to apply changes.",
+                            "Config file has changed since startup. "
+                            "Please restart the worker to apply changes.",
                         )
 
                     max_retries = pipeline.config.max_retries
@@ -375,7 +390,8 @@ class Worker:
                             )
                             audit_db.add_record(result)
                             logger.error(
-                                "Pipeline retries exhausted for sample %s job %s pipeline %s (attempt %d/%d): %s",
+                                "Pipeline retries exhausted for sample %s job "
+                                "%s pipeline %s (attempt %d/%d): %s",
                                 climb_id,
                                 job_uuid,
                                 pipeline.config.name,
@@ -389,7 +405,8 @@ class Worker:
 
                         next_attempt = current_attempt + 1
                         logger.warning(
-                            "Retrying pipeline %s for sample %s job %s (next attempt %d/%d): %s",
+                            "Retrying pipeline %s for sample %s job %s "
+                            "(next attempt %d/%d): %s",
                             pipeline.config.name,
                             climb_id,
                             job_uuid,
@@ -425,7 +442,8 @@ class Worker:
                         )
                         audit_db.add_record(result)
                         logger.error(
-                            "Non-retryable pipeline error for sample %s job %s pipeline %s (attempt %d/%d): %s",
+                            "Non-retryable pipeline error for sample %s job "
+                            "%s pipeline %s (attempt %d/%d): %s",
                             climb_id,
                             job_uuid,
                             pipeline.config.name,

--- a/src/cherami/pipelines/worker.py
+++ b/src/cherami/pipelines/worker.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import time
@@ -29,8 +30,8 @@ class PipelineResult:
     error_message: str | None = None
     attempt: int | None = None
     max_attempts: int | None = None
-    start_time: float | None = None
-    end_time: float | None = None
+    start_time: str | None = None
+    end_time: str | None = None
     duration: float | None = None
 
 
@@ -217,8 +218,8 @@ class Worker:
         error_message: str | None = None,
         attempt: int | None = None,
         max_attempts: int | None = None,
-        start_time: float | None = None,
-        end_time: float | None = None,
+        start_time: datetime.datetime | None = None,
+        end_time: datetime.datetime | None = None,
     ) -> PipelineResult:
         """Create a structured result object for audit logging.
 
@@ -239,11 +240,15 @@ class Worker:
             A PipelineResult used for the audit database.
         """
         duration = (
-            end_time - start_time
+            (end_time - start_time).total_seconds()
             ## skipped samples dont have start/end times
             if start_time is not None and end_time is not None
             else None
         )
+
+        start_time_str = start_time.isoformat("T") if start_time else None
+        end_time_str = end_time.isoformat("T") if end_time else None
+
         return PipelineResult(
             climb_id=climb_id,
             job_uuid=job_uuid,
@@ -252,8 +257,8 @@ class Worker:
             error_message=error_message,
             attempt=attempt,
             max_attempts=max_attempts,
-            start_time=start_time,
-            end_time=end_time,
+            start_time=start_time_str,
+            end_time=end_time_str,
             duration=duration,
         )
 
@@ -340,7 +345,10 @@ class Worker:
                         current_attempt,
                         total_attempts,
                     )
-                    start_time = time.time()
+                    start_time: datetime.datetime = datetime.datetime.now(
+                        datetime.UTC
+                    )
+
                     try:
                         self._runner.run_pipeline(
                             pipeline=pipeline,
@@ -348,9 +356,10 @@ class Worker:
                             job_uuid=job_uuid,
                             worker_work_dir=self.work_dir,
                             worker_output_dir=self.output_dir,
+                            execution_timestamp=start_time,
                         )
                     except RetryablePipelineError as e:
-                        end_time = time.time()
+                        end_time = datetime.datetime.now(datetime.UTC)
                         error_message = str(e)
                         if current_attempt >= total_attempts:
                             self._retry_counts.pop(climb_id, None)
@@ -402,7 +411,7 @@ class Worker:
                         self.on_retry(message)
                         continue
                     except NonRetryablePipelineError as e:
-                        end_time = time.time()
+                        end_time = datetime.datetime.now(datetime.UTC)
                         self._retry_counts.pop(climb_id, None)
                         result = self._create_result(
                             climb_id=climb_id,
@@ -428,7 +437,7 @@ class Worker:
                             "Non-retryable pipeline error"
                         ) from e
 
-                    end_time = time.time()
+                    end_time = datetime.datetime.now(datetime.UTC)
                     self._retry_counts.pop(climb_id, None)
                     result = self._create_result(
                         climb_id=climb_id,

--- a/tests/pipelines/test_worker.py
+++ b/tests/pipelines/test_worker.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 from pathlib import Path
 
@@ -92,10 +93,9 @@ def test_create_result_with_timing(worker):
         climb_id="C123ABC",
         job_uuid="JOB123",
         status="SUCCESS",
-        start_time=100.0,
-        end_time=105.5,
+        start_time=dt.datetime.fromtimestamp(100.0, tz=dt.UTC),
+        end_time=dt.datetime.fromtimestamp(105.5, tz=dt.UTC),
     )
-
-    assert result.start_time == 100.0
-    assert result.end_time == 105.5
     assert result.duration == 5.5
+    assert result.start_time == "1970-01-01T00:01:40+00:00"
+    assert result.end_time == "1970-01-01T00:01:45.500000+00:00"

--- a/tests/test_audit_db.py
+++ b/tests/test_audit_db.py
@@ -22,8 +22,8 @@ def sample_result():
         error_message=None,
         attempt=1,
         max_attempts=3,
-        start_time=1000.0,
-        end_time=1060.0,
+        start_time="1000.0",
+        end_time="1060.0",
         duration=60.0,
     )
 
@@ -38,7 +38,7 @@ def test_init_db_creates_table(audit_db):
             "climb_id",
             "job_uuid",
             "pipeline_name",
-            "timestamp",
+            "audit_timestamp",
             "status",
             "error_message",
             "attempt",
@@ -69,7 +69,7 @@ def test_add_record_success(audit_db, sample_result):
         assert row["status"] == sample_result.status
         assert row["attempt"] == sample_result.attempt
         assert row["duration"] == sample_result.duration
-        assert row["timestamp"] is not None
+        assert row["audit_timestamp"] is not None
 
 
 def test_add_record_skipped(audit_db):


### PR DESCRIPTION
This merge adds an execution datetime stamp to the output directories as handled in _create_dirs in the pipeline_runner. The execution_timestamp is created in worker.run then fed as an argument into the relevant methods. 
Audit db still takes a timestamp at time of adding (field name change to audit_timestamp to avoid confusion) and the start time and end time are now passed as strings of the datetime object. 
Datetime is given in UTC.