### PR TITLE
42 fix/pipeline trace check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,18 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+    - id: trailing-whitespace
+      name: Check for a blank line at the end of scripts (auto-fixes)
+    - id: end-of-file-fixer
+      name: Check for trailing whitespaces (auto-fixes)
+- repo: local
+  hooks:
+    - id: climb-id-checker
+      name: Check if climb ID pattern is present.
+      types: ["file"]
+      args: [--multiline]
+      entry: '[CA]-[A-F0-9]{5}'
+      language: pygrep

--- a/src/cherami/pipelines/pipeline.py
+++ b/src/cherami/pipelines/pipeline.py
@@ -98,7 +98,16 @@ class Pipeline(ABC):
                             row["name"],
                             row["exit"],
                         )
-                        process_exitcodes[row["name"]].append(row["exit"])
+                    except KeyError as k:
+                        logger.error(
+                            "Expected to find column %s in trace file. "
+                            "Cannot validate processes",
+                            k,
+                        )
+                        return False
+
+                    process_exitcodes[row["name"]].append(row["exit"])
+
                 # If the dict is empty, the file is empty (with or without header)
                 if not process_exitcodes:
                     logger.error("Trace file %s is empty.", trace_file)

--- a/src/cherami/pipelines/pipeline.py
+++ b/src/cherami/pipelines/pipeline.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import os
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -83,17 +84,29 @@ class Pipeline(ABC):
         try:
             with trace_file.open("r") as f:
                 reader = csv.DictReader(f, delimiter="\t")
-                ## by default check all processes for exit code 0
+
                 if not self.proc_names:
+                    process_exitcodes_dict = defaultdict(list)
                     for row in reader:
-                        if row["exit"] != "0":
+                        process_exitcodes_dict[row["name"]].append(row["exit"])
+                    ## by default check all processes contain at least one 0 exitcode.
+                    ## this does not assume that the pipeline trace file is added in chronological
+                    ## order
+                    failing_processes = {
+                        k: v
+                        for k, v in process_exitcodes_dict.items()
+                        if "0" not in v
+                    }
+                    if failing_processes:
+                        for process, exitcodes in failing_processes:
                             logger.warning(
-                                "Process %s failed with exit code %s",
-                                row["name"],
-                                row["exit"],
+                                "Process %s failed with exit code(s) %s",
+                                process,
+                                exitcodes,
                             )
-                            return False
+                        return False
                     return True
+
                 ## if proc_names provided - determine allowed exit codes per process
                 ## this also allows you to only check a subset of processes if you want
                 for row in reader:

--- a/src/cherami/pipelines/pipeline.py
+++ b/src/cherami/pipelines/pipeline.py
@@ -73,19 +73,18 @@ class Pipeline(ABC):
         Returns:
             `True` if the trace file exists and every relevant process satisfies its
             defined exit code, otherwise `False`.
-
-        Raises:
-            KeyError: If the trace file is missing required columns.
-            ValueError: If an exit code cannot be parsed.
         """
         if not trace_file.exists():
+            logger.error("Trace file %s does not exist.", trace_file)
             return False
 
         try:
             with trace_file.open("r") as f:
                 reader = csv.DictReader(f, delimiter="\t")
 
-                process_exitcodes: defaultdict = defaultdict(list)
+                process_exitcodes: defaultdict[str, list[int | str]] = (
+                    defaultdict(list)
+                )
                 for row in reader:
                     # If there is a line of empty 'columns', skip
                     if all(val == "" for val in row.values()):
@@ -93,36 +92,40 @@ class Pipeline(ABC):
                     try:
                         process_exitcodes[row["name"]].append(int(row["exit"]))
                     except ValueError:
-                        logger.error(
-                            "ERROR: Expected integer-like exitcode in trace"
+                        logger.warning(
+                            "Expected integer-like exitcode in trace"
                             "file for process %s, got %s",
                             row["name"],
                             row["exit"],
                         )
-
+                        process_exitcodes[row["name"]].append(row["exit"])
                 # If the dict is empty, the file is empty (with or without header)
                 if not process_exitcodes:
-                    logger.warning(
-                        "WARNING: Trace file %s is empty.", trace_file
-                    )
+                    logger.error("Trace file %s is empty.", trace_file)
                     return False
                 # If proc_names provided - determine allowed exit codes per
                 # process. This also allows you to only check a subset of
                 # processes if you want
-                failing_processes = {}
+                failing_processes: dict[str, list[int | str]] = {}
                 if self.proc_names:
                     for proc, ec in process_exitcodes.items():
                         if proc in self.proc_names:
                             allowed_ec: set[int] = set(self.proc_names[proc])
                             if not any(e in allowed_ec for e in ec):
                                 failing_processes[proc] = ec
+                        else:
+                            failing_processes = {
+                                proc: ec
+                                for proc, ec in process_exitcodes.items()
+                                if 0 not in ec
+                            }
 
                 # By default, check all processes contain at least one 0
                 # exitcode. This does not assume that the pipeline trace file
                 # is added in chronological order, but does assume that a
                 # process can't fail AFTER it has completed succesfully
                 else:
-                    failing_processes: dict[str, str] = {
+                    failing_processes = {
                         proc: ec
                         for proc, ec in process_exitcodes.items()
                         if 0 not in ec
@@ -130,7 +133,7 @@ class Pipeline(ABC):
                 # Write to log
                 if failing_processes:
                     for proc, ecs in failing_processes.items():
-                        logger.warning(
+                        logger.error(
                             "Process %s failed with exit code(s) %s",
                             proc,
                             ecs,

--- a/src/cherami/pipelines/pipeline.py
+++ b/src/cherami/pipelines/pipeline.py
@@ -98,6 +98,7 @@ class Pipeline(ABC):
                             row["name"],
                             row["exit"],
                         )
+                        process_exitcodes[row["name"]].append(row["exit"])
                     except KeyError as k:
                         logger.error(
                             "Expected to find column %s in trace file. "
@@ -105,8 +106,6 @@ class Pipeline(ABC):
                             k,
                         )
                         return False
-
-                    process_exitcodes[row["name"]].append(row["exit"])
 
                 # If the dict is empty, the file is empty (with or without header)
                 if not process_exitcodes:

--- a/src/cherami/pipelines/pipeline.py
+++ b/src/cherami/pipelines/pipeline.py
@@ -89,16 +89,18 @@ class Pipeline(ABC):
                     process_exitcodes_dict = defaultdict(list)
                     for row in reader:
                         process_exitcodes_dict[row["name"]].append(row["exit"])
-                    ## by default check all processes contain at least one 0 exitcode.
-                    ## this does not assume that the pipeline trace file is added in chronological
-                    ## order
+                    # By default, check all processes contain at least one 0
+                    # exitcode. This does not assume that the pipeline trace
+                    # file is added in chronological order, but does assume
+                    # that a process can't fail AFTER it has completed
+                    # succesfully.
                     failing_processes = {
                         k: v
                         for k, v in process_exitcodes_dict.items()
                         if "0" not in v
                     }
                     if failing_processes:
-                        for process, exitcodes in failing_processes:
+                        for process, exitcodes in failing_processes.items():
                             logger.warning(
                                 "Process %s failed with exit code(s) %s",
                                 process,
@@ -107,8 +109,9 @@ class Pipeline(ABC):
                         return False
                     return True
 
-                ## if proc_names provided - determine allowed exit codes per process
-                ## this also allows you to only check a subset of processes if you want
+                # If proc_names provided - determine allowed exit codes per
+                # process. This also allows you to only check a subset of
+                # processes if you want
                 for row in reader:
                     if row["name"] in self.proc_names:
                         allowed_exit_codes = self.proc_names[row["name"]]

--- a/src/cherami/pipelines/pipeline.py
+++ b/src/cherami/pipelines/pipeline.py
@@ -104,28 +104,22 @@ class Pipeline(ABC):
                     logger.error("Trace file %s is empty.", trace_file)
                     return False
                 # If proc_names provided - determine allowed exit codes per
-                # process. This also allows you to only check a subset of
+                # process deinfe. This allows you to ONLY check a subset of
                 # processes if you want
-                failing_processes: dict[str, list[int | str]] = {}
                 if self.proc_names:
+                    failing_processes: dict[str, list[int | str]] = {}
                     for proc, ec in process_exitcodes.items():
                         if proc in self.proc_names:
                             allowed_ec: set[int] = set(self.proc_names[proc])
                             if not any(e in allowed_ec for e in ec):
                                 failing_processes[proc] = ec
-                        else:
-                            failing_processes = {
-                                proc: ec
-                                for proc, ec in process_exitcodes.items()
-                                if 0 not in ec
-                            }
 
                 # By default, check all processes contain at least one 0
                 # exitcode. This does not assume that the pipeline trace file
                 # is added in chronological order, but does assume that a
                 # process can't fail AFTER it has completed succesfully
                 else:
-                    failing_processes = {
+                    failing_processes: dict[str, list[int | str]] = {
                         proc: ec
                         for proc, ec in process_exitcodes.items()
                         if 0 not in ec

--- a/src/cherami/pipelines/pipeline.py
+++ b/src/cherami/pipelines/pipeline.py
@@ -85,44 +85,59 @@ class Pipeline(ABC):
             with trace_file.open("r") as f:
                 reader = csv.DictReader(f, delimiter="\t")
 
-                if not self.proc_names:
-                    process_exitcodes_dict = defaultdict(list)
-                    for row in reader:
-                        process_exitcodes_dict[row["name"]].append(row["exit"])
-                    # By default, check all processes contain at least one 0
-                    # exitcode. This does not assume that the pipeline trace
-                    # file is added in chronological order, but does assume
-                    # that a process can't fail AFTER it has completed
-                    # succesfully.
-                    failing_processes = {
-                        k: v
-                        for k, v in process_exitcodes_dict.items()
-                        if "0" not in v
-                    }
-                    if failing_processes:
-                        for process, exitcodes in failing_processes.items():
-                            logger.warning(
-                                "Process %s failed with exit code(s) %s",
-                                process,
-                                exitcodes,
-                            )
-                        return False
-                    return True
+                process_exitcodes: defaultdict = defaultdict(list)
+                for row in reader:
+                    # If there is a line of empty 'columns', skip
+                    if all(val == "" for val in row.values()):
+                        continue
+                    try:
+                        process_exitcodes[row["name"]].append(int(row["exit"]))
+                    except ValueError:
+                        logger.error(
+                            "ERROR: Expected integer-like exitcode in trace"
+                            "file for process %s, got %s",
+                            row["name"],
+                            row["exit"],
+                        )
 
+                # If the dict is empty, the file is empty (with or without header)
+                if not process_exitcodes:
+                    logger.warning(
+                        "WARNING: Trace file %s is empty.", trace_file
+                    )
+                    return False
                 # If proc_names provided - determine allowed exit codes per
                 # process. This also allows you to only check a subset of
                 # processes if you want
-                for row in reader:
-                    if row["name"] in self.proc_names:
-                        allowed_exit_codes = self.proc_names[row["name"]]
-                        if int(row["exit"]) not in allowed_exit_codes:
-                            logger.warning(
-                                "Process %s failed with exit code %s",
-                                row["name"],
-                                row["exit"],
-                            )
-                            return False
+                failing_processes = {}
+                if self.proc_names:
+                    for proc, ec in process_exitcodes.items():
+                        if proc in self.proc_names:
+                            allowed_ec: set[int] = set(self.proc_names[proc])
+                            if not any(e in allowed_ec for e in ec):
+                                failing_processes[proc] = ec
+
+                # By default, check all processes contain at least one 0
+                # exitcode. This does not assume that the pipeline trace file
+                # is added in chronological order, but does assume that a
+                # process can't fail AFTER it has completed succesfully
+                else:
+                    failing_processes: dict[str, str] = {
+                        proc: ec
+                        for proc, ec in process_exitcodes.items()
+                        if 0 not in ec
+                    }
+                # Write to log
+                if failing_processes:
+                    for proc, ecs in failing_processes.items():
+                        logger.warning(
+                            "Process %s failed with exit code(s) %s",
+                            proc,
+                            ecs,
+                        )
+                    return False
                 return True
+
         except FileNotFoundError:
             return False
 

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -104,7 +104,7 @@ def test_eval_exit_status_should_pass(pipeline, trace_file):
 )
 def test_eval_exit_status_should_fail(pipeline, trace_file, caplog):
     assert pipeline.evaluate_exit_status(trace_file) is False
-    assert "WARNING" in caplog.text
+    assert "ERROR" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -165,7 +165,7 @@ def test_eval_exit_status__fail_then_complete_should_pass(
 )
 def test_eval_exit_status__one_fails(pipeline, trace_file, caplog):
     assert pipeline.evaluate_exit_status(trace_file) is False
-    assert "WARNING" in caplog.text
+    assert "ERROR" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -274,7 +274,7 @@ def test_eval_exit_status_proc_names_completes_invalid_exitcode(
     pipeline_proc_names, trace_file, caplog
 ):
     assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
-    assert "WARNING" in caplog.text
+    assert "ERROR" in caplog.text
 
 
 def test_eval_exit_status__entirely_empty_trace_file(
@@ -282,7 +282,7 @@ def test_eval_exit_status__entirely_empty_trace_file(
 ):
     """Check that entirely empty file returns false and logs warning."""
     assert pipeline_proc_names.evaluate_exit_status(empty_trace_file) is False
-    assert "WARNING" in caplog.text
+    assert "ERROR" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -292,9 +292,11 @@ def test_eval_exit_status__entirely_empty_trace_file(
 def test_eval_exit_status__empty_trace_file(
     pipeline_proc_names, trace_file, caplog
 ):
-    """Check that file just with header and newline returns false and logs warning."""
+    """
+    Check that file just with header and newline returns false and logs error.
+    """
     assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
-    assert "WARNING" in caplog.text
+    assert "ERROR" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -321,7 +323,7 @@ def test_eval_exit_status__empty_rows_then_rows(
     Check that a csv with an empty line (with columns though) is handled.
     """
     assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
-    assert "WARNING" in caplog.text
+    assert "ERROR" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -339,4 +341,82 @@ def test_eval_exit_status__bad_exitcodes(
     pipeline_proc_names, trace_file, caplog
 ):
     assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
+    # should get warning about non-int exitcode and error about failing exitcode.
+    assert "WARNING" in caplog.text
+    assert "got not a real exitcode" in caplog.text
     assert "ERROR" in caplog.text
+    assert "failed with exit code" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        (
+            "1\t82/cac9ec\tnf-82cac7edfcf0128514abf5f17718a8af-b277c\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tFAILED\t1\t"
+            "2025-09-24 12:16:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "2\t82/cac9ed\tnf-82cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t5\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "3\t82/cac9ee\tnf-82cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:18:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "4\t83/cacfff\tnf-83cac7edfcf0128514abf5f17718a8af-bffff\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tFAILED\t-\t"
+            "2025-09-24 12:20:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
+    ],
+)
+def test_eval_exit_status__fails_nonint_exitcode(
+    pipeline_proc_names, trace_file, caplog
+):
+    """If one process fails with non-integer exitcode and doesn't complete at
+    all, it should fail overall."""
+    assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
+    # should get warning about non-int exitcode and error about failing exitcode.
+    assert "WARNING" in caplog.text
+    assert "got -" in caplog.text
+    assert "ERROR" in caplog.text
+    assert "failed with exit code" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        (
+            "1\t80/cac7ed\tnf-80cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "2\t80/cac7ef\tnf-80cac7edfcf0128514abf5f17718a8af-b277f\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tFAILED\t1\t"
+            "2025-09-24 12:18:37.440\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "3\t80/cac7eg\tnf-80cac7edfcf0128514abf5f17718a8af-b277g\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:19:37.441\t13.6s\t9s\t164.1%\t526.8 MB\7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "4\t80/cac7eh\tnf-80cac7edfcf0128514abf5f17718a8af-b277h\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE3_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:20:37.442\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "5\t80/cac7ex\tnf-80cac7edfcf0128514abf5f17718a8af-b277x\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE4_PE)\tFAILED\t-\t"
+            "2025-09-24 12:20:37.443\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
+    ],
+)
+def test_eval_exit_status__one_failswith_noninteger_exitcode(
+    pipeline, trace_file, caplog
+):
+    assert pipeline.evaluate_exit_status(trace_file) is False
+    # should get warning about non-int exitcode and error about non-zero exitcode.
+    assert "WARNING" in caplog.text
+    assert "got -" in caplog.text
+    assert "ERROR" in caplog.text
+    assert "failed with exit code" in caplog.text

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -69,6 +69,13 @@ def trace_file(tmp_path, content):
     return trace_path
 
 
+@pytest.fixture
+def empty_trace_file(tmp_path):
+    trace_path = tmp_path / "trace.tsv"
+    trace_path.touch()
+    return trace_path
+
+
 @pytest.mark.parametrize(
     "content",
     [
@@ -227,14 +234,109 @@ def test_eval_exit_status_proc_names_should_pass(
     "content",
     [
         (
+            "1\t82/cac9ec\tnf-82cac7edfcf0128514abf5f17718a8af-b277c\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tFAILED\t1\t"
+            "2025-09-24 12:16:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "2\t82/cac9ed\tnf-82cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t5\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "3\t82/cac9ed\tnf-82cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:18:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
+    ],
+)
+def test_eval_exit_status_proc_names_fails_then_completes(
+    pipeline_proc_names, trace_file
+):
+    assert pipeline_proc_names.evaluate_exit_status(trace_file) is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        (
             "4\t83/cacaed\tnf-83cac7edfcf0128514abf5f17718a8af-b277e\t"
-            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t1\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tFAILED\t1\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "5\t83/cacaee\tnf-83cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t2\t"
+            "2025-09-24 12:18:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
+    ],
+)
+def test_eval_exit_status_proc_names_completes_invalid_exitcode(
+    pipeline_proc_names, trace_file, caplog
+):
+    assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
+    assert "WARNING" in caplog.text
+
+
+def test_eval_exit_status__entirely_empty_trace_file(
+    pipeline_proc_names, empty_trace_file, caplog
+):
+    """Check that entirely empty file returns false and logs warning."""
+    assert pipeline_proc_names.evaluate_exit_status(empty_trace_file) is False
+    assert "WARNING" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["\n"],
+)
+def test_eval_exit_status__empty_trace_file(
+    pipeline_proc_names, trace_file, caplog
+):
+    """Check that file just with header and newline returns false and logs warning."""
+    assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
+    assert "WARNING" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        (
+            "\n\t\t\t\t\t\t\t\t\t\t\t\t\t\n"
+            "4\t83/cacaed\tnf-83cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tFAILED\t1\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "\n\t\t\t\t\t\t\t\t\t\t\t\t\t\n"
+            "5\t83/cacaee\tnf-83cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t2\t"
+            "2025-09-24 12:18:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
+    ],
+)
+def test_eval_exit_status__empty_rows_then_rows(
+    pipeline_proc_names, trace_file, caplog
+):
+    """
+    Check that a csv with an empty line (with columns though) is handled.
+    """
+    assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
+    assert "WARNING" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        (
+            "4\t83/cacaed\tnf-83cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tFAILED\tnot a real exitcode\t"
             "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
             "19.5 MB\t4.6 MB\n"
         ),
     ],
 )
-def test_eval_exit_status_proc_names_should_fail(
-    pipeline_proc_names, trace_file
+def test_eval_exit_status__bad_exitcodes(
+    pipeline_proc_names, trace_file, caplog
 ):
     assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
+    assert "ERROR" in caplog.text

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -371,17 +371,15 @@ def test_eval_exit_status__bad_exitcodes(
         ),
     ],
 )
-def test_eval_exit_status__fails_nonint_exitcode(
-    pipeline_proc_names, trace_file, caplog
+def test_eval_exit_status__ignores_nonint_exitcode(
+    pipeline_proc_names, trace_file
 ):
-    """If one process fails with non-integer exitcode and doesn't complete at
-    all, it should fail overall."""
-    assert pipeline_proc_names.evaluate_exit_status(trace_file) is False
-    # should get warning about non-int exitcode and error about failing exitcode.
-    assert "WARNING" in caplog.text
-    assert "got -" in caplog.text
-    assert "ERROR" in caplog.text
-    assert "failed with exit code" in caplog.text
+    """
+    One process fails with non-integer exitcode BUT that process is
+    not defined in proc_names, so it will pass. Only process SAMPLE1_PE is
+    checked.
+    """
+    assert pipeline_proc_names.evaluate_exit_status(trace_file) is True
 
 
 @pytest.mark.parametrize(

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -60,7 +60,10 @@ def pipeline_proc_names(pipeline_config):
 def trace_file(tmp_path, content):
     trace_path = tmp_path / "trace.tsv"
     trace_path.write_text(
-        "task_id\thash\tnative_id\tname\tstatus\texit\tsubmit\tduration\trealtime\t%cpu\tpeak_rss\tpeak_vmem\trchar\twchar\n"
+        (
+            "task_id\thash\tnative_id\tname\tstatus\texit\tsubmit\tduration\t"
+            "realtime\t%cpu\tpeak_rss\tpeak_vmem\trchar\twchar\n"
+        )
         + content,
     )
     return trace_path
@@ -69,7 +72,12 @@ def trace_file(tmp_path, content):
 @pytest.mark.parametrize(
     "content",
     [
-        "1\t80/cac7ed\tnf-80cac7edfcf0128514abf5f17718a8af-b277e\tNFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t19.5 MB\t4.6 MB\n",
+        (
+            "1\t80/cac7ed\tnf-80cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
     ],
 )
 def test_eval_exit_status_should_pass(pipeline, trace_file):
@@ -79,17 +87,134 @@ def test_eval_exit_status_should_pass(pipeline, trace_file):
 @pytest.mark.parametrize(
     "content",
     [
-        "1\t80/cac7ed\tnf-80cac7edfcf0128514abf5f17718a8af-b277e\tNFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t1\t2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t19.5 MB\t4.6 MB\n",
+        (
+            "1\t80/cac7ed\tnf-80cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t1\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
     ],
 )
-def test_eval_exit_status_should_fail(pipeline, trace_file):
+def test_eval_exit_status_should_fail(pipeline, trace_file, caplog):
     assert pipeline.evaluate_exit_status(trace_file) is False
+    assert "WARNING" in caplog.text
 
 
 @pytest.mark.parametrize(
     "content",
     [
-        "2\t82/cac9ed\tnf-82cac7edfcf0128514abf5f17718a8af-b277e\tNFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t5\t2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t19.5 MB\t4.6 MB\n3\t82/cac9ed\tnf-82cac7edfcf0128514abf5f17718a8af-b277e\tNFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t19.5 MB\t4.6 MB\n",
+        (
+            "1\t80/cac7ed\tnf-80cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "2\t80/cac7ef\tnf-80cac7edfcf0128514abf5f17718a8af-b277f\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tFAILED\t1\t"
+            "2025-09-24 12:17:37.440\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "3\t80/cac7eg\tnf-80cac7edfcf0128514abf5f17718a8af-b277g\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.441\t13.6s\t9s\t164.1%\t526.8 MB\7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "4\t80/cac7eh\tnf-80cac7edfcf0128514abf5f17718a8af-b277h\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE3_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.442\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
+    ],
+)
+def test_eval_exit_status__fail_then_complete_should_pass(
+    pipeline, trace_file
+):
+    assert pipeline.evaluate_exit_status(trace_file) is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        (
+            "1\t80/cac7ed\tnf-80cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "2\t80/cac7ef\tnf-80cac7edfcf0128514abf5f17718a8af-b277f\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tFAILED\t1\t"
+            "2025-09-24 12:17:37.440\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "3\t80/cac7eg\tnf-80cac7edfcf0128514abf5f17718a8af-b277g\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.441\t13.6s\t9s\t164.1%\t526.8 MB\7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "4\t80/cac7eh\tnf-80cac7edfcf0128514abf5f17718a8af-b277h\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE3_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.442\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "5\t80/cac7ex\tnf-80cac7edfcf0128514abf5f17718a8af-b277x\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE4_PE)\tFAILED\t1\t"
+            "2025-09-24 12:17:37.443\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t1"
+            "9.5 MB\t4.6 MB\n"
+        ),
+    ],
+)
+def test_eval_exit_status__one_fails(pipeline, trace_file, caplog):
+    assert pipeline.evaluate_exit_status(trace_file) is False
+    assert "WARNING" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        (
+            "4\t80/cac7ef\tnf-80cac7edfcf0128514abf5f17718a8af-b277f\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tFAILED\t1\t"
+            "2025-09-24 12:14:37.440\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "2\t80/cac7ef\tnf-80cac7edfcf0128514abf5f17718a8af-b277f\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tFAILED\t1\t"
+            "2025-09-24 12:12:37.440\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "5\t80/cac7eh\tnf-80cac7edfcf0128514abf5f17718a8af-b277h\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE3_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.442\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "1\t80/cac7ed\tnf-80cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:10:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "6\t80/cac7eg\tnf-80cac7edfcf0128514abf5f17718a8af-b277g\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:19:37.440\t13.6s\t9s\t164.1%\t526.8 MB\7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "3\t80/cac7ef\tnf-80cac7edfcf0128514abf5f17718a8af-b277f\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE2_PE)\tFAILED\t1\t"
+            "2025-09-24 12:13:37.440\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
+    ],
+)
+def test_eval_exit_status__not_chronological(pipeline, trace_file):
+    """
+    Check that if the pipeline trace file is not chronological, any Complete
+    for process will still returns True. Noting that this still assumes the
+    last process will complete. It assumes Nextflow will not schedule a process
+    that completes, then afterwards schedules the same process that fails.
+    """
+    assert pipeline.evaluate_exit_status(trace_file) is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        (
+            "2\t82/cac9ed\tnf-82cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t5\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+            "3\t82/cac9ed\tnf-82cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t0\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
     ],
 )
 def test_eval_exit_status_proc_names_should_pass(
@@ -101,7 +226,12 @@ def test_eval_exit_status_proc_names_should_pass(
 @pytest.mark.parametrize(
     "content",
     [
-        "4\t83/cacaed\tnf-83cac7edfcf0128514abf5f17718a8af-b277e\tNFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t1\t2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t19.5 MB\t4.6 MB\n",
+        (
+            "4\t83/cacaed\tnf-83cac7edfcf0128514abf5f17718a8af-b277e\t"
+            "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tCOMPLETED\t1\t"
+            "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+            "19.5 MB\t4.6 MB\n"
+        ),
     ],
 )
 def test_eval_exit_status_proc_names_should_fail(

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -418,3 +418,25 @@ def test_eval_exit_status__one_failswith_noninteger_exitcode(
     assert "got -" in caplog.text
     assert "ERROR" in caplog.text
     assert "failed with exit code" in caplog.text
+
+
+@pytest.fixture
+def missing_col_trace_file(tmp_path):
+    trace_path = tmp_path / "missing_trace.tsv"
+    trace_path.write_text(
+        "task_id\thash\tnative_id\tname\tstatus\tsubmit\tduration\t"
+        "realtime\t%cpu\tpeak_rss\tpeak_vmem\trchar\twchar\n"
+        "4\t83/cacaed\tnf-83cac7edfcf0128514abf5f17718a8af-b277e\t"
+        "NFCORE_DEMO:DEMO:FASTQC (SAMPLE1_PE)\tFAILED\t"
+        "2025-09-24 12:17:37.439\t13.6s\t9s\t164.1%\t526.8 MB\t7.1 GB\t"
+        "19.5 MB\t4.6 MB\n"
+    )
+    return trace_path
+
+
+def test_eval_exit_status__missing_col_in_file(
+    pipeline, missing_col_trace_file, caplog
+):
+    assert pipeline.evaluate_exit_status(missing_col_trace_file) is False
+    assert "ERROR" in caplog.text
+    assert "Expected to find column 'exit'" in caplog.text


### PR DESCRIPTION
Improved the pipeline_trace file check to allow Nextflow processes that fail and then complete to not trigger pipeline non-retryable error.

Also updated the pre-commit config to include pygrep for IDs and check trailing space/new lines (unit standards)

Closes #42 