### PR TITLE
Renames max_retries to max_attempts in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
+## unreleased v1.0.0
 
-All notable changes to this project will be documented in this file.
+### Changed
+- _breaking_: allow the user to explicitly set the number of attempts for a pipeline - this is validated at config parse time that this value is >=1. This is a breaking to change to all configs.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 
 ## [0.1.0]
 

--- a/docs/dev_adding_new_pipeline.md
+++ b/docs/dev_adding_new_pipeline.md
@@ -48,7 +48,7 @@ Create a new configuration file in `configs/` (e.g., `configs/cherami_my_pipelin
     "namespace": "ns-synthscape-ukhsa",
     "container": "quay.io/climb-tre/nextflow",
     "backoff_limit": 5,
-    "max_retries": 1,
+    "max_attempts": 2,
     "retry_timeout": 10,
     "job_timeout": 3600
   },
@@ -163,7 +163,7 @@ The default `Worker` class (`src/cherami/pipelines/worker.py`) is sufficient for
 1. Listens to the configured exchange.
 2. Launches the pipeline.
 3. On success: Optionally republishes to a downstream queue (if `publish_queue_suffix` is set).
-4. On failure: Retries up to `max_retries` before giving up.
+4. On failure: Retries until `max_attempts` is exhausted.
 
 ### Custom Worker
 You can however, extend the base `Worker` if you need custom orchestration logic:

--- a/docs/dev_config.md
+++ b/docs/dev_config.md
@@ -54,7 +54,7 @@ These settings configure the `Pipeline` object and the Kubernetes Jobs it spawns
 | `namespace` | Yes | Kubernetes namespace where the Job will run. |
 | `container` | Yes | Container image used to execute the Nextflow head process. |
 | `backoff_limit` | Yes | Maximum number of pod restarts allowed before the Job is marked as failed. |
-| `max_retries` | Yes | Maximum number of times Cherami will retry a failed sample analysis. |
+| `max_attempts` | Yes | Total number of attempts Cherami will make for a failed sample analysis (must be at least 1). |
 | `retry_timeout` | Yes | Wait time (in seconds) between retries. |
 | `job_timeout` | Yes | Maximum execution time (in seconds) before the Job is timed out. |
 
@@ -95,7 +95,7 @@ Below is a minimal valid configuration. See `configs/cherami_amr.json` or `confi
     "namespace": "my-namespace",
     "container": "quay.io/climb-tre/nextflow",
     "backoff_limit": 5,
-    "max_retries": 1,
+    "max_attempts": 2,
     "retry_timeout": 10,
     "job_timeout": 3600
   },

--- a/src/cherami/config.py
+++ b/src/cherami/config.py
@@ -26,7 +26,7 @@ class PipelineConfig:
     namespace: str
     container: str
     backoff_limit: int
-    max_retries: int
+    max_attempts: int
     retry_timeout: int
     job_timeout: int
 
@@ -35,10 +35,10 @@ class PipelineConfig:
         """Returns a PipelineConfig parsed from a raw config dictionary.
 
         Raises:
-            ValueError: If a required field is missing.
+            ValueError: If a required field is missing or max_attempts is less than 1.
         """
         try:
-            return cls(
+            pipeline = cls(
                 name=str(raw_config["name"]),
                 version=str(raw_config["version"]),
                 path=str(raw_config["path"]),
@@ -52,7 +52,7 @@ class PipelineConfig:
                 namespace=str(raw_config["namespace"]),
                 container=str(raw_config["container"]),
                 backoff_limit=int(raw_config["backoff_limit"]),
-                max_retries=int(raw_config["max_retries"]),
+                max_attempts=int(raw_config["max_attempts"]),
                 retry_timeout=int(raw_config["retry_timeout"]),
                 job_timeout=int(raw_config["job_timeout"]),
             )
@@ -60,6 +60,9 @@ class PipelineConfig:
             raise ValueError(
                 f"Pipeline missing required field: {error.args[0]}"
             ) from error
+        if pipeline.max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
+        return pipeline
 
 
 @dataclass(frozen=True)
@@ -154,35 +157,42 @@ def load_config(config_path: Path) -> CheramiConfig:
 
     Raises:
         OSError: If the config file cannot be read.
-        json.JSONDecodeError: If the config file is not valid JSON.
-        ValueError: If required config sections or fields are missing.
+        ValueError: If the config file is not valid JSON or fields are missing or invalid.
         Exception: If the pipeline module cannot be loaded.
     """
-    with config_path.open("r") as f:
-        raw_config = json.load(f)
+    try:
+        with config_path.open("r") as f:
+            raw_config = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"{config_path}: invalid JSON: {e.msg} (line {e.lineno}, col {e.colno})"
+        ) from e
     start_hash = hash_from_raw(raw_config)
 
-    raw_global = raw_config.get("global")
-    if raw_global is None:
-        raise ValueError("Config missing 'global' section")
-    global_config = GlobalConfig.from_dict(raw_global)
+    try:
+        raw_global = raw_config.get("global")
+        if raw_global is None:
+            raise ValueError("missing 'global' section")
+        global_config = GlobalConfig.from_dict(raw_global)
 
-    raw_pipeline = raw_config.get("pipeline")
-    if raw_pipeline is None:
-        raise ValueError("Config missing 'pipeline' section")
-    pipeline_config = PipelineConfig.from_dict(raw_pipeline)
-    from cherami.pipelines import load_pipeline_module
+        raw_pipeline = raw_config.get("pipeline")
+        if raw_pipeline is None:
+            raise ValueError("missing 'pipeline' section")
+        pipeline_config = PipelineConfig.from_dict(raw_pipeline)
+        from cherami.pipelines import load_pipeline_module
 
-    load_pipeline_module(pipeline_config.name)
+        load_pipeline_module(pipeline_config.name)
 
-    raw_worker = raw_config.get("worker")
-    if raw_worker is None:
-        raise ValueError("Config missing 'worker' section")
-    worker_config = WorkerConfig.from_dict(
-        raw_worker,
-        config_path,
-        start_hash,
-    )
+        raw_worker = raw_config.get("worker")
+        if raw_worker is None:
+            raise ValueError("missing 'worker' section")
+        worker_config = WorkerConfig.from_dict(
+            raw_worker,
+            config_path,
+            start_hash,
+        )
+    except ValueError as e:
+        raise ValueError(f"{config_path}: {e}") from e
 
     return CheramiConfig(
         global_config=global_config,

--- a/src/cherami/config.py
+++ b/src/cherami/config.py
@@ -164,9 +164,8 @@ def load_config(config_path: Path) -> CheramiConfig:
         with config_path.open("r") as f:
             raw_config = json.load(f)
     except json.JSONDecodeError as e:
-        raise ValueError(
-            f"{config_path}: invalid JSON: {e.msg} (line {e.lineno}, col {e.colno})"
-        ) from e
+        e.add_note(f"invalid JSON in config file: {config_path}")
+        raise
     start_hash = hash_from_raw(raw_config)
 
     try:
@@ -192,7 +191,8 @@ def load_config(config_path: Path) -> CheramiConfig:
             start_hash,
         )
     except ValueError as e:
-        raise ValueError(f"{config_path}: {e}") from e
+        e.add_note(f"while reading config file: {config_path}")
+        raise
 
     return CheramiConfig(
         global_config=global_config,

--- a/src/cherami/pipelines/worker.py
+++ b/src/cherami/pipelines/worker.py
@@ -151,8 +151,8 @@ class Worker:
 
         The default implementation negatively acknowledges (nacks) the message,
         returning it to the queue for redelivery. The worker tracks retry
-        counts internally and calls to `on_sample_failure` if `max_retries` is
-        exceeded.
+        counts internally and calls to `on_sample_failure` if `max_attempts` is
+        exhausted.
 
         Override this method to implement custom retry strategies.
 
@@ -245,7 +245,7 @@ class Worker:
                 (SUCCESS, FAILED, SKIPPED, RETRY).
             error_message: Description of the error if failed or retried.
             attempt: Current attempt number.
-            max_attempts: Total allowed retry attempts.
+            max_attempts: Total allowed attempts.
             start_time: Timestamp when execution started.
             end_time: Timestamp when execution finished.
 
@@ -307,8 +307,8 @@ class Worker:
                 ## logic. If it does not pass, call `on_skip` to ack and move to next sample. If it does pass, call
                 ## `run_pipeline` on the `PipelineRunner` instance to then launch the pipeline. Exceptions indicate
                 ## failure states. If success, call `on_success` to ack and potentially publish to next queue. If
-                ## failure, it will be retried up to `max_retries`, calling `on_retry` to nack the message so
-                ## it goes back to the queue. If max_retries is exceeded, call `on_sample_failure` to ack and handle
+                ## failure, it will be retried up to `max_attempts`, calling `on_retry` to nack the message so
+                ## it goes back to the queue. If max_attempts is exhausted, call `on_sample_failure` to ack and handle
                 # the error to move on.
                 try:
                     message = self._varys_client.receive(
@@ -349,8 +349,7 @@ class Worker:
                             "Please restart the worker to apply changes.",
                         )
 
-                    max_retries = pipeline.config.max_retries
-                    total_attempts = max_retries + 1
+                    total_attempts = pipeline.config.max_attempts
                     current_attempt = self._retry_counts.get(climb_id, 0) + 1
                     self._retry_counts[climb_id] = current_attempt
 

--- a/tests/pipelines/test_pipeline.py
+++ b/tests/pipelines/test_pipeline.py
@@ -39,7 +39,7 @@ def pipeline_config():
         namespace="imafake-ns",
         container="nextflow/nextflow:latest",
         backoff_limit=3,
-        max_retries=2,
+        max_attempts=2,
         retry_timeout=300,
         job_timeout=3600,
     )

--- a/tests/pipelines/test_pipeline_manifest.py
+++ b/tests/pipelines/test_pipeline_manifest.py
@@ -27,7 +27,7 @@ def pipeline_config():
         namespace="imafake-ns",
         container="nextflow/nextflow:latest",
         backoff_limit=3,
-        max_retries=2,
+        max_attempts=2,
         retry_timeout=300,
         job_timeout=3600,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,7 @@ def valid_pipeline():
         "namespace": "imafake-ns",
         "container": "nextflow/nextflow:latest",
         "backoff_limit": 3,
-        "max_retries": 2,
+        "max_attempts": 2,
         "retry_timeout": 300,
         "job_timeout": 3600,
     }
@@ -158,11 +158,38 @@ def test_load_config_valid(
     mock_load.assert_called_once_with("test-pipeline")
 
 
-def test_load_config_fail(tmp_path, valid_global):
+def test_load_config_valid_but_incomplete(tmp_path, valid_global):
     config_data = {"global": valid_global}
     config_file = tmp_path / "incomplete_config.json"
     with config_file.open("w") as f:
         json.dump(config_data, f)
 
-    with pytest.raises(ValueError, match="Config missing 'pipeline' section"):
+    with pytest.raises(ValueError, match="missing 'pipeline' section"):
+        load_config(config_file)
+
+
+def test_load_config_invalid_json(tmp_path):
+    config_file = tmp_path / "bad.json"
+    config_file.write_text('{"max_attempts": iminvalidjson}')
+
+    with pytest.raises(ValueError, match="invalid JSON"):
+        load_config(config_file)
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_load_config_maxattempts_wrong_value(
+    tmp_path, valid_global, valid_pipeline, valid_worker, mocker, value
+):
+    mocker.patch("cherami.pipelines.load_pipeline_module")
+    valid_pipeline["max_attempts"] = value
+    config_data = {
+        "global": valid_global,
+        "pipeline": valid_pipeline,
+        "worker": valid_worker,
+    }
+    config_file = tmp_path / "config.json"
+    with config_file.open("w") as f:
+        json.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="max_attempts must be at least 1"):
         load_config(config_file)


### PR DESCRIPTION
Addresses #32 

Previous behavior wanted a user to set a number of retries allowed. Internally this was always incremented by 1 to get the total number of attempts. This felt unintuitive as a user would have to set 0 if you only wanted one run.

New behavior is to allow the user to set explicitly the number of attempts for a pipeline - and validates at config parse time that this value is >=1.

This is a breaking to change to all configs - which will need to be updated once merged so we can hold off on this until ready.

